### PR TITLE
Allow swapping Guzzle/ClientInterface 

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -8,10 +8,10 @@
 namespace ConvertKit_API;
 
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
-
+use GuzzleHttp\ClientInterface;
+use Monolog\Handler\StreamHandler;
 /**
  * ConvertKit API Class
  */
@@ -69,7 +69,7 @@ class ConvertKit_API
     /**
      * Guzzle Http Client
      *
-     * @var \GuzzleHttp\Client
+     * @var \GuzzleHttp\ClientInterface
      */
     protected $client;
 
@@ -103,6 +103,18 @@ class ConvertKit_API
                 $stream_handler // phpcs:ignore Squiz.Objects.ObjectInstantiation.NotAssigned
             );
         }
+    }
+
+    /**
+     * Set the Guzzle client implementation to use.
+     *
+     * @param ClientInterface $client Guzzle client implementation.
+     *
+     * @return void
+     */
+    public function set_http_client(ClientInterface $client)
+    {
+        $this->client = $client;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR adds a set_http_client() method to ConvertKit_API that accepts a GuzzleHttp\ClientInterface. This would allow for more easily testing the package when integrating with other frameworks without hitting the network or needing to set up API credentials and dummy data.

## Testing

`testClientInterfaceInjection()`

Injects a GuzzleHttp\Handler\MockHandler and asserts the results are as expected.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)