### PR TITLE
Tests: Run PHPStan Static Analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,11 @@ jobs:
       - name: Build PHP Autoloader
         run: composer dump-autoload
 
+      # Run PHPStan for static analysis.
+      - name: Run PHPStan Static Analysis
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpstan analyse --memory-limit=1250M
+
       # Run Coding Standards.
       - name: Run Coding Standards
         run: php vendor/bin/phpcs --standard=phpcs.xml

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -142,7 +142,7 @@ class ConvertKit_API
         // Mask email addresses that may be contained within the message.
         $message = preg_replace_callback(
             '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})^',
-            function ($matches) {
+            function ($matches) { // @phpstan-ignore-line - see https://github.com/phpstan/phpstan/issues/10396
                 return preg_replace('/\B[^@.]/', '*', $matches[0]);
             },
             $message


### PR DESCRIPTION
## Summary

Runs PHPStan static analysis when running tests via GitHub Actions.  Not sure why this wasn't included before, given it's used on the WordPress Plugins and documented as a testing step.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)