### PR TITLE
Add `get_subscriber_stats` method

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1028,6 +1028,20 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Get the email statistics for a specific subscriber.
+     *
+     * @param integer $id Subscriber ID.
+     *
+     * @see https://developers.kit.com/api-reference/subscribers/list-stats-for-a-subscriber
+     *
+     * @return mixed|object
+     */
+    public function get_subscriber_stats(int $id)
+    {
+        return $this->get(sprintf('subscribers/%s/stats', $id));
+    }
+
+    /**
      * Get a list of the tags for a subscriber.
      *
      * @param integer $subscriber_id       Subscriber ID.

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1723,6 +1723,49 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_subscriber_stats() returns the expected data
+     * when using a valid subscriber ID.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetSubscriberStats()
+    {
+        $result = $this->api->get_subscriber_stats(
+            id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+        );
+        $this->assertArrayHasKey('subscriber', get_object_vars($result));
+        $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
+        $this->assertArrayHasKey('stats', get_object_vars($result->subscriber));
+        $this->assertArrayHasKey('sent', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('opened', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('clicked', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('bounced', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('open_rate', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('click_rate', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_sent', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_opened', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_clicked', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('sends_since_last_open', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('sends_since_last_click', get_object_vars($result->subscriber->stats));
+    }
+
+    /**
+     * Test that get_subscriber_stats() throws a ClientException when an invalid
+     * subscriber ID is specified.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetSubscriberStatsWithInvalidSubscriberID()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->get_subscriber_stats(12345);
+    }
+
+    /**
      * Test that tag_subscriber_by_email() returns the expected data.
      *
      * @since   1.0.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1776,6 +1776,49 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_subscriber_stats() returns the expected data
+     * when using a valid subscriber ID.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetSubscriberStats()
+    {
+        $result = $this->api->get_subscriber_stats(
+            id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+        );
+        $this->assertArrayHasKey('subscriber', get_object_vars($result));
+        $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
+        $this->assertArrayHasKey('stats', get_object_vars($result->subscriber));
+        $this->assertArrayHasKey('sent', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('opened', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('clicked', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('bounced', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('open_rate', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('click_rate', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_sent', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_opened', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('last_clicked', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('sends_since_last_open', get_object_vars($result->subscriber->stats));
+        $this->assertArrayHasKey('sends_since_last_click', get_object_vars($result->subscriber->stats));
+    }
+
+    /**
+     * Test that get_subscriber_stats() throws a ClientException when an invalid
+     * subscriber ID is specified.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetSubscriberStatsWithInvalidSubscriberID()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->get_subscriber_stats(12345);
+    }
+
+    /**
      * Test that tag_subscriber_by_email() returns the expected data.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds a method for [fetching a subscriber's stats](https://developers.kit.com/api-reference/subscribers/list-stats-for-a-subscriber).

## Testing

- `testGetSubscriberStats`: Test that get_subscriber_stats() returns the expected data when using a valid subscriber ID.
- `testGetSubscriberStatsWithInvalidSubscriberID`: Test that get_subscriber_stats() throws a ClientException when an invalid subscriber ID is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)