### PR TITLE
Add `get_broadcast_link_clicks` method

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1197,6 +1197,41 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * List link clicks for a specific broadcast.
+     *
+     * @param integer $id                  Broadcast ID.
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
+     *
+     * @since 2.2.1
+     *
+     * @see https://developers.kit.com/api-reference/broadcasts/get-link-clicks-for-a-broadcast
+     *
+     * @return false|mixed
+     */
+    public function get_broadcast_link_clicks(
+        int $id,
+        bool $include_total_count = false,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
+        // Send request.
+        return $this->get(
+            sprintf('broadcasts/%s/clicks', $id),
+            $this->build_total_count_and_pagination_params(
+                [],
+                $include_total_count,
+                $after_cursor,
+                $before_cursor,
+                $per_page
+            )
+        );
+    }
+
+    /**
      * Updates a broadcast.
      *
      * @param integer              $id                Broadcast ID.

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4191,6 +4191,101 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_broadcast_link_clicks() returns the expected data.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetBroadcastLinkClicks()
+    {
+        // Get broadcast link clicks.
+        $result = $this->api->get_broadcast_link_clicks(
+            $_ENV['CONVERTKIT_API_BROADCAST_ID'],
+            per_page: 1
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcast');
+        $this->assertPaginationExists($result);
+
+        // Assert a single broadcast was returned.
+        $this->assertCount(1, $result->broadcasts);
+
+        // Assert has_previous_page and has_next_page are correct.
+        $this->assertFalse($result->pagination->has_previous_page);
+        $this->assertTrue($result->pagination->has_next_page);
+
+        // Use pagination to fetch next page.
+        $result = $this->api->get_broadcasts_stats(
+            per_page: 1,
+            after_cursor: $result->pagination->end_cursor
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcast');
+        $this->assertPaginationExists($result);
+
+        // Assert a single broadcast was returned.
+        $this->assertCount(1, $result->broadcasts);
+
+        // Assert has_previous_page and has_next_page are correct.
+        $this->assertTrue($result->pagination->has_previous_page);
+        $this->assertTrue($result->pagination->has_next_page);
+
+        // Use pagination to fetch previous page.
+        $result = $this->api->get_broadcasts_stats(
+            per_page: 1,
+            before_cursor: $result->pagination->start_cursor
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+        $this->assertPaginationExists($result);
+
+        // Assert a single webhook was returned.
+        $this->assertCount(1, $result->broadcasts);
+    }
+
+    /**
+     * Test that get_broadcast_link_clicks() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetBroadcastLinkClicksWithTotalCount()
+    {
+        $result = $this->api->get_broadcast_link_clicks(
+            $_ENV['CONVERTKIT_API_BROADCAST_ID'],
+            include_total_count: true
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcast');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
+    }
+
+    /**
+     * Test that get_broadcast_link_clicks() throws a ClientException when an invalid
+     * broadcast ID is specified.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testGetBroadcastLinkClicksWithInvalidBroadcastID()
+    {
+        $this->expectException(ClientException::class);
+        $this->api->get_broadcast_link_clicks(12345);
+    }
+
+    /**
      * Test that update_broadcast() throws a ClientException when an invalid
      * broadcast ID is specified.
      *


### PR DESCRIPTION
## Summary

Adds a method for [fetching link clicks for a broadcast](https://developers.kit.com/api-reference/broadcasts/get-link-clicks-for-a-broadcast).

## Testing

- `testGetBroadcastLinkClicks `: Test that `get_broadcast_link_clicks()` returns the expected data and pagination works.
- `testGetBroadcastLinkClicksWithTotalCount`: Test that `get_broadcast_link_clicks()` includes the total count when required.
- `testGetBroadcastLinkClicksWithInvalidBroadcastID`: Test that get_broadcast_link_clicks() throws a ClientException when an invalid broadcast ID is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)