### PR TITLE
Add `update_tag_name` method

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -586,6 +586,23 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Updates the name of a tag.
+     *
+     * @param integer $tag_id Tag ID.
+     * @param string  $name   New name.
+     *
+     * @since 2.2.1
+     *
+     * @see https://developers.kit.com/api-reference/tags/update-tag-name
+     *
+     * @return false|mixed
+     */
+    public function update_tag_name(int $tag_id, string $name)
+    {
+        return $this->put(sprintf('tags/%s', $tag_id), ['name' => $name]);
+    }
+
+    /**
      * Tags a subscriber with the given existing Tag.
      *
      * @param integer $tag_id        Tag ID.

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1735,6 +1735,10 @@ class ConvertKitAPITest extends TestCase
             tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
             name: $_ENV['CONVERTKIT_API_TAG_NAME'],
         );
+
+        // Assert existing tag is returned.
+        $this->assertEquals($result->tag->id, (int) $_ENV['CONVERTKIT_API_TAG_ID']);
+        $this->assertEquals($result->tag->name, $_ENV['CONVERTKIT_API_TAG_NAME']);
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1723,6 +1723,55 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that update_tag_name() returns the expected data.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testUpdateTagName()
+    {
+        $result = $this->api->update_tag_name(
+            tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+            name: $_ENV['CONVERTKIT_API_TAG_NAME'],
+        );
+    }
+
+    /**
+     * Test that update_tag_name() throws a ClientException when an invalid
+     * tag ID is specified.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testUpdateTagNameWithInvalidTagID()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->update_tag_name(
+            tag_id: 12345,
+            name: $_ENV['CONVERTKIT_API_TAG_NAME'],
+        );
+    }
+
+    /**
+     * Test that update_tag_name() throws a ClientException when a blank
+     * name is specified.
+     *
+     * @since   2.2.1
+     *
+     * @return void
+     */
+    public function testUpdateTagNameWithBlankName()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->update_tag_name(
+            tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+            name: ''
+        );
+    }
+
+    /**
      * Test that tag_subscriber_by_email() returns the expected data.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds a method for [updating a tag name](https://developers.kit.com/api-reference/tags/update-tag-name).

## Testing

- `testUpdateTagName`: Test that `update_tag_name()` returns the expected data.
- `testUpdateTagNameWithInvalidTagID`: Test that `update_tag_name()` throws a ClientException when an invalid tag ID is specified.
- `testUpdateTagNameWithBlankName`: Test that `update_tag_name()` throws a ClientException when a blank tag name is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)