### PR TITLE
Move WordPress Libraries Methods to Trait

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -328,21 +328,11 @@ class ConvertKit_API
         $this->convert_relative_to_absolute_urls($html->getElementsByTagName('script'), 'src', $url_scheme_host_only);
         $this->convert_relative_to_absolute_urls($html->getElementsByTagName('form'), 'action', $url_scheme_host_only);
 
-        // Save HTML.
-        $resource = $html->saveHTML();
-
-        // If the result is false, return a blank string.
-        if (!$resource) {
-            throw new \Exception(sprintf('Could not parse %s', $url));
-        }
-
         // Remove some HTML tags that DOMDocument adds, returning the output.
         // We do this instead of using LIBXML_HTML_NOIMPLIED in loadHTML(), because Legacy Forms
         // are not always contained in a single root / outer element, which is required for
         // LIBXML_HTML_NOIMPLIED to correctly work.
-        $resource = $this->strip_html_head_body_tags($resource);
-
-        return $resource;
+        return $this->get_body_html($html);
     }
 
     /**

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -274,7 +274,6 @@ class ConvertKit_API
      * @param string $url URL of HTML page.
      *
      * @throws \InvalidArgumentException If the URL is not a valid URL format.
-     * @throws \Exception If parsing the legacy form or landing page failed.
      *
      * @return false|string
      */

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1931,6 +1931,12 @@ trait ConvertKit_API_Traits
                 continue;
             }
 
+            // Remove element if it's rocket-loader.min.js. Including it prevents landing page redirects from working.
+            if (strpos($element->getAttribute($attribute), 'rocket-loader.min.js') !== false) {
+                $element->parentNode->removeChild($element);
+                continue;
+            }
+
             // If here, the attribute's value is a relative URL, missing the http(s) and domain.
             // Prepend the URL to the attribute's value.
             $element->setAttribute($attribute, $url . $element->getAttribute($attribute));
@@ -1947,15 +1953,29 @@ trait ConvertKit_API_Traits
      */
     public function strip_html_head_body_tags(string $markup)
     {
-        $markup = str_replace('<html>', '', $markup);
-        $markup = str_replace('</html>', '', $markup);
-        $markup = str_replace('<head>', '', $markup);
-        $markup = str_replace('</head>', '', $markup);
-        $markup = str_replace('<body>', '', $markup);
-        $markup = str_replace('</body>', '', $markup);
-        $markup = str_replace('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', '', $markup);
+        return $this->get_body_html($markup);
+    }
 
-        return $markup;
+    /**
+     * Returns the HTML within the DOMDocument's <body> tag as a string.
+     *
+     * @param \DOMDocument $dom DOM Document.
+     * 
+     * @since   2.1.0
+     *
+     * @return  string
+     */
+    public function get_body_html(\DOMDocument $dom) {
+
+        $body = $dom->getElementsByTagName( 'body' )->item( 0 );
+
+        $html = '';
+        foreach ( $body->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+            $html .= $dom->saveHTML( $child );
+        }
+
+        return $html;
+
     }
 
     /**

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -316,7 +316,7 @@ trait ConvertKit_API_Traits
      *
      * @since 2.0.0
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function add_subscriber_to_legacy_form(int $form_id, int $subscriber_id)
     {
@@ -1952,7 +1952,9 @@ trait ConvertKit_API_Traits
 
             // Remove element if it's rocket-loader.min.js. Including it prevents landing page redirects from working.
             if (strpos($element->getAttribute($attribute), 'rocket-loader.min.js') !== false) {
-                $element->parentNode->removeChild($element);
+                if ($element->parentNode instanceof \DOMNode) {
+                    $element->parentNode->removeChild($element);
+                }
                 continue;
             }
 
@@ -1974,6 +1976,10 @@ trait ConvertKit_API_Traits
     public function get_body_html(\DOMDocument $dom)
     {
         $body = $dom->getElementsByTagName('body')->item(0);
+
+        if (! $body instanceof \DOMElement) {
+            return '';
+        }
 
         $html = '';
         foreach ($body->childNodes as $child) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1914,8 +1914,12 @@ trait ConvertKit_API_Traits
      */
     public function convert_relative_to_absolute_urls(\DOMNodeList $elements, string $attribute, string $url) // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint, Generic.Files.LineLength.TooLong
     {
-        // Anchor hrefs.
+        $nodes = [];
         foreach ($elements as $element) {
+            $nodes[] = $element;
+        }
+
+        foreach ($nodes as $element) {
             // Skip if the attribute's value is empty.
             if (empty($element->getAttribute($attribute))) {
                 continue;
@@ -1941,19 +1945,6 @@ trait ConvertKit_API_Traits
             // Prepend the URL to the attribute's value.
             $element->setAttribute($attribute, $url . $element->getAttribute($attribute));
         }
-    }
-
-    /**
-     * Strips <html>, <head> and <body> opening and closing tags from the given markup,
-     * as well as the Content-Type meta tag we might have added in get_html().
-     *
-     * @param string $markup HTML Markup.
-     *
-     * @return string              HTML Markup
-     */
-    public function strip_html_head_body_tags(string $markup)
-    {
-        return $this->get_body_html($markup);
     }
 
     /**

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -309,6 +309,21 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Adds a subscriber to a legacy form by subscriber ID
+     *
+     * @param integer $form_id       Legacy Form ID.
+     * @param integer $subscriber_id Subscriber ID.
+     *
+     * @since 2.0.0
+     *
+     * @return WP_Error|array
+     */
+    public function add_subscriber_to_legacy_form(int $form_id, int $subscriber_id)
+    {
+        return $this->post(sprintf('landing_pages/%s/subscribers/%s', $form_id, $subscriber_id));
+    }
+
+    /**
      * List subscribers for a form
      *
      * @param integer        $form_id             Form ID.
@@ -1944,29 +1959,28 @@ trait ConvertKit_API_Traits
             // If here, the attribute's value is a relative URL, missing the http(s) and domain.
             // Prepend the URL to the attribute's value.
             $element->setAttribute($attribute, $url . $element->getAttribute($attribute));
-        }
+        }//end foreach
     }
 
     /**
      * Returns the HTML within the DOMDocument's <body> tag as a string.
      *
      * @param \DOMDocument $dom DOM Document.
-     * 
-     * @since   2.1.0
      *
-     * @return  string
+     * @since 2.1.0
+     *
+     * @return string
      */
-    public function get_body_html(\DOMDocument $dom) {
-
-        $body = $dom->getElementsByTagName( 'body' )->item( 0 );
+    public function get_body_html(\DOMDocument $dom)
+    {
+        $body = $dom->getElementsByTagName('body')->item(0);
 
         $html = '';
-        foreach ( $body->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-            $html .= $dom->saveHTML( $child );
+        foreach ($body->childNodes as $child) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+            $html .= $dom->saveHTML($child);
         }
 
         return $html;
-
     }
 
     /**

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1929,6 +1929,7 @@ trait ConvertKit_API_Traits
      */
     public function convert_relative_to_absolute_urls(\DOMNodeList $elements, string $attribute, string $url) // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint, Generic.Files.LineLength.TooLong
     {
+        // Store DOMNodeList in array, as iteration stops if a node is modified.
         $nodes = [];
         foreach ($elements as $element) {
             $nodes[] = $element;

--- a/tests/ConvertKitMethodsTest.php
+++ b/tests/ConvertKitMethodsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Dotenv\Dotenv;
+use ConvertKit_API\ConvertKit_API;
+
+/**
+ * Test methods in ConvertKit_API_Traits that don't interact with the API,
+ * such as convert_relative_to_absolute_urls().
+ */
+class ConvertKitMethodsTest extends TestCase
+{
+    /**
+     * Kit API Class
+     *
+     * @var object
+     */
+    protected $api;
+
+    /**
+     * Initialize the API class before each test.
+     *
+     * @since   2.4.1
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        $this->api = new ConvertKit_API();
+    }
+
+    /**
+     * Test the convert_relative_to_absolute_urls() method.
+     *
+     * @since   2.4.1
+     *
+     * @return  void
+     */
+    public function testConvertRelativeToAbsoluteUrls()
+    {
+        // Setup HTML in DOMDocument.
+        $html = new \DOMDocument();
+        $html->loadHTML('<html>
+            <head>
+                <script type="text/javascript" src="rocket-loader.min.js"></script>
+                <link rel="stylesheet" href="//fonts.googleapis.com">
+            </head>
+            <body>
+                <a href="/test">Test</a>
+                <img src="/test.jpg" />
+                <script type="text/javascript" src="/test.js"></script>
+                <form action="/test">Test</form>
+            </body>
+        </html>');
+
+        // Define URL to prepend to relative URLs.
+        $url_scheme_host_only = 'https://example.com';
+
+        // Convert relative URLs to absolute URLs for elements we want to test.
+        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('a'), 'href', $url_scheme_host_only);
+        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('link'), 'href', $url_scheme_host_only);
+        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('img'), 'src', $url_scheme_host_only);
+        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('script'), 'src', $url_scheme_host_only);
+        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('form'), 'action', $url_scheme_host_only);
+
+        // Fetch HTML string.
+        $output = $html->saveHTML();
+
+        // Assert string contains expected HTML elements that should not be modified.
+        $this->assertStringContainsString('<link rel="stylesheet" href="//fonts.googleapis.com">', $output);
+
+        // Assert string does not contain HTML elements that should be removed.
+        $this->assertStringNotContainsString('<script type="text/javascript" src="rocket-loader.min.js"></script>', $output);
+
+        // Assert string contains expected HTML elements that should be modified.
+        $this->assertStringContainsString('<a href="' . $url_scheme_host_only . '/test">Test</a>', $output);
+        $this->assertStringContainsString('<img src="' . $url_scheme_host_only . '/test.jpg">', $output);
+        $this->assertStringContainsString('<script type="text/javascript" src="' . $url_scheme_host_only . '/test.js"></script>', $output);
+        $this->assertStringContainsString('<form action="' . $url_scheme_host_only . '/test">Test</form>', $output);
+    }
+
+    /**
+	 * Test that the get_body_html() method returns the expected HTML.
+	 *
+	 * @since   2.4.1
+	 */
+    public function testGetBodyHtml()
+    {
+        $content  = '<h1>Vantar þinn ungling sjálfstraust í stærðfræði?</h1><p>This is a test</p>';
+        $html = new \DOMDocument();
+        $html->loadHTML('<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>'.$content.'</body></html>');
+        $this->assertEquals($content, $this->api->get_body_html($html));
+    }
+}

--- a/tests/ConvertKitMethodsTest.php
+++ b/tests/ConvertKitMethodsTest.php
@@ -57,11 +57,31 @@ class ConvertKitMethodsTest extends TestCase
         $url_scheme_host_only = 'https://example.com';
 
         // Convert relative URLs to absolute URLs for elements we want to test.
-        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('a'), 'href', $url_scheme_host_only);
-        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('link'), 'href', $url_scheme_host_only);
-        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('img'), 'src', $url_scheme_host_only);
-        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('script'), 'src', $url_scheme_host_only);
-        $this->api->convert_relative_to_absolute_urls($html->getElementsByTagName('form'), 'action', $url_scheme_host_only);
+        $this->api->convert_relative_to_absolute_urls(
+            $html->getElementsByTagName('a'),
+            'href',
+            $url_scheme_host_only
+        );
+        $this->api->convert_relative_to_absolute_urls(
+            $html->getElementsByTagName('link'),
+            'href',
+            $url_scheme_host_only
+        );
+        $this->api->convert_relative_to_absolute_urls(
+            $html->getElementsByTagName('img'),
+            'src',
+            $url_scheme_host_only
+        );
+        $this->api->convert_relative_to_absolute_urls(
+            $html->getElementsByTagName('script'),
+            'src',
+            $url_scheme_host_only
+        );
+        $this->api->convert_relative_to_absolute_urls(
+            $html->getElementsByTagName('form'),
+            'action',
+            $url_scheme_host_only
+        );
 
         // Fetch HTML string.
         $output = $html->saveHTML();
@@ -70,25 +90,43 @@ class ConvertKitMethodsTest extends TestCase
         $this->assertStringContainsString('<link rel="stylesheet" href="//fonts.googleapis.com">', $output);
 
         // Assert string does not contain HTML elements that should be removed.
-        $this->assertStringNotContainsString('<script type="text/javascript" src="rocket-loader.min.js"></script>', $output);
+        $this->assertStringNotContainsString(
+            '<script type="text/javascript" src="rocket-loader.min.js"></script>',
+            $output
+        );
 
         // Assert string contains expected HTML elements that should be modified.
-        $this->assertStringContainsString('<a href="' . $url_scheme_host_only . '/test">Test</a>', $output);
-        $this->assertStringContainsString('<img src="' . $url_scheme_host_only . '/test.jpg">', $output);
-        $this->assertStringContainsString('<script type="text/javascript" src="' . $url_scheme_host_only . '/test.js"></script>', $output);
-        $this->assertStringContainsString('<form action="' . $url_scheme_host_only . '/test">Test</form>', $output);
+        $this->assertStringContainsString(
+            '<a href="' . $url_scheme_host_only . '/test">Test</a>',
+            $output
+        );
+        $this->assertStringContainsString(
+            '<img src="' . $url_scheme_host_only . '/test.jpg">',
+            $output
+        );
+        $this->assertStringContainsString(
+            '<script type="text/javascript" src="' . $url_scheme_host_only . '/test.js"></script>',
+            $output
+        );
+        $this->assertStringContainsString(
+            '<form action="' . $url_scheme_host_only . '/test">Test</form>',
+            $output
+        );
     }
 
     /**
-	 * Test that the get_body_html() method returns the expected HTML.
-	 *
-	 * @since   2.4.1
-	 */
+     * Test that the get_body_html() method returns the expected HTML.
+     *
+     * @since   2.4.1
+     */
     public function testGetBodyHtml()
     {
         $content  = '<h1>Vantar þinn ungling sjálfstraust í stærðfræði?</h1><p>This is a test</p>';
         $html = new \DOMDocument();
-        $html->loadHTML('<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>'.$content.'</body></html>');
+        $html->loadHTML('
+            <html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+            <body>' . $content . '</body>
+            </html>');
         $this->assertEquals($content, $this->api->get_body_html($html));
     }
 }


### PR DESCRIPTION
## Summary

To facilitate using the `ConvertKit_API_Traits` trait directly in the Kit WordPress Libraries, without any changes, this PR standardises the trait by:
- Adding the `get_body_html` method, which uses DOMDocument vs. string search/replace
- Removes the unused and deprecated `strip_html_head_body_tags` method
- Fixes a bug in `convert_relative_to_absolute_urls` that would stop after the first change to a node in the NodeList 

## Testing

- `ConvertKitMethodsTest`: Test the `convert_relative_to_absolute_urls` and `get_body_html` methods work correctly with unit tests

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)