### PR TITLE
Tests: Replace `bounced` tests with `cancelled`

### DIFF
--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -722,11 +722,11 @@ class ConvertKitAPITest extends TestCase
      *
      * @return void
      */
-    public function testGetFormSubscriptionsWithBouncedSubscriberState()
+    public function testGetFormSubscriptionsWithCancelledSubscriberState()
     {
         $result = $this->api->get_form_subscriptions(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
-            subscriber_state: 'bounced'
+            subscriber_state: 'cancelled'
         );
 
         // Assert subscribers and pagination exist.
@@ -734,7 +734,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertEquals($result->subscribers[0]->state, 'bounced');
+        $this->assertEquals($result->subscribers[0]->state, 'cancelled');
     }
 
     /**
@@ -1238,11 +1238,11 @@ class ConvertKitAPITest extends TestCase
      *
      * @return void
      */
-    public function testGetSequenceSubscriptionsWithBouncedSubscriberState()
+    public function testGetSequenceSubscriptionsWithCancelledSubscriberState()
     {
         $result = $this->api->get_sequence_subscriptions(
             sequence_id: (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            subscriber_state: 'bounced'
+            subscriber_state: 'cancelled'
         );
 
         // Assert subscribers and pagination exist.
@@ -1250,7 +1250,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertEquals($result->subscribers[0]->state, 'bounced');
+        $this->assertEquals($result->subscribers[0]->state, 'cancelled');
     }
 
     /**
@@ -2284,17 +2284,17 @@ class ConvertKitAPITest extends TestCase
     /**
      * Test that get_tag_subscriptions() returns the expected data
      * when a valid Tag ID is specified and the subscription status
-     * is bounced.
+     * is cancelled.
      *
      * @since   1.0.0
      *
      * @return void
      */
-    public function testGetTagSubscriptionsWithBouncedSubscriberState()
+    public function testGetTagSubscriptionsWithCancelledSubscriberState()
     {
         $result = $this->api->get_tag_subscriptions(
             tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
-            subscriber_state: 'bounced'
+            subscriber_state: 'cancelled'
         );
 
         // Assert subscribers and pagination exist.
@@ -2302,7 +2302,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertEquals($result->subscribers[0]->state, 'bounced');
+        $this->assertEquals($result->subscribers[0]->state, 'cancelled');
     }
 
 
@@ -3153,16 +3153,16 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_subscribers() returns the expected data
-     * when the subscription status is bounced.
+     * when the subscription status is cancelled.
      *
      * @since   1.0.0
      *
      * @return void
      */
-    public function testGetSubscribersWithBouncedSubscriberState()
+    public function testGetSubscribersWithCancelledSubscriberState()
     {
         $result = $this->api->get_subscribers(
-            subscriber_state: 'bounced'
+            subscriber_state: 'cancelled'
         );
 
         // Assert subscribers and pagination exist.
@@ -3170,7 +3170,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertEquals($result->subscribers[0]->state, 'bounced');
+        $this->assertEquals($result->subscribers[0]->state, 'cancelled');
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes failing tests by checking for cancelled subscribers, as there are no bounced subscribers with forms, tags and sequences in the Kit account:

<img width="670" height="94" alt="Screenshot 2026-05-15 at 21 17 47" src="https://github.com/user-attachments/assets/dc5b1bfd-9d9e-40c5-8635-7c241734bb12" />

## Testing

- Updated existing tests

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)