### PR TITLE
Fix Composer Commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
   "scripts": {
     "create-docs": "phpDocumentor --directory=src --target=docs --template='vendor/saggre/phpdocumentor-markdown/themes/markdown'",
     "phpcs": "vendor/bin/phpcs --standard=phpcs.xml -s -v", 
-    "phpcbf": "vendor/bin/phpcbf --standard=phpcs.tests.xml -s -v",
-    "phpcs-tests": "vendor/bin/phpcs --standard=phpcs.xml -s -v",
+    "phpcbf": "vendor/bin/phpcbf --standard=phpcs.xml -s -v",
+    "phpcs-tests": "vendor/bin/phpcs --standard=phpcs.tests.xml -s -v",
     "phpcbf-tests": "vendor/bin/phpcbf --standard=phpcs.tests.xml -s -v",
     "phpstan": "vendor/bin/phpstan analyse --memory-limit=1250M",
     "php-coding-standards": "vendor/bin/phpcs --standard=phpcs.xml -s -v",


### PR DESCRIPTION
## Summary

Corrects the `phpcbf` and `phpcs-tests` commands to use the correct XML configuration.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)