### PR TITLE
Run Tests Sequentially

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
     # Defines PHP Versions matrix to run tests on
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
 


### PR DESCRIPTION
## Summary

To avoid 429 rate limits, runs tests for each PHP version sequentially, rather than in parallel.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)