### PR TITLE
Add `slim` query parameter support

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1212,6 +1212,7 @@ trait ConvertKit_API_Traits
      * @param \DateTime|null $created_before      Filter subscribers who have been created before this date.
      * @param \DateTime|null $tagged_after        Filter subscribers who have been tagged after this date.
      * @param \DateTime|null $tagged_before       Filter subscribers who have been tagged before this date.
+     * @param boolean        $slim                When true, omits expensive optional fields from the response.
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -1228,13 +1229,14 @@ trait ConvertKit_API_Traits
         \DateTime|null $created_before = null,
         \DateTime|null $tagged_after = null,
         \DateTime|null $tagged_before = null,
+        bool $slim = false,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
         // Build parameters.
-        $options = [];
+        $options = ['slim' => $slim];
 
         if (!empty($subscriber_state)) {
             $options['status'] = $subscriber_state;
@@ -1750,6 +1752,7 @@ trait ConvertKit_API_Traits
      *
      * @param \DateTime|null $sent_after          Get broadcasts sent after the given date.
      * @param \DateTime|null $sent_before         Get broadcasts sent before the given date.
+     * @param boolean        $slim                When true, omits expensive optional fields from the response.
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -1762,13 +1765,14 @@ trait ConvertKit_API_Traits
     public function get_broadcasts(
         \DateTime|null $sent_after = null,
         \DateTime|null $sent_before = null,
+        bool $slim = false,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
         // Build parameters.
-        $options = [];
+        $options = ['slim' => $slim];
 
         if (!is_null($sent_after)) {
             $options['sent_after'] = $sent_after->format('Y-m-d');

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -2961,6 +2961,30 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_tag_subscriptions() returns the expected data
+     * when the slim parameter is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetTagSubscriptionsSlim()
+    {
+        $result = $this->api->get_tag_subscriptions(
+            tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+            slim: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Confirm custom field values are excluded from the data.
+        $broadcast = get_object_vars($result->subscribers[0]);
+        $this->assertArrayNotHasKey('fields', $broadcast);
+    }
+
+    /**
+     * Test that get_tag_subscriptions() returns the expected data
      * when the total count is included.
      *
      * @since   2.0.0
@@ -5290,6 +5314,33 @@ class ConvertKitAPITest extends TestCase
 
         // Assert the expected number of broadcasts were returned.
         $this->assertCount(12, $result->broadcasts);
+    }
+
+    /**
+     * Test that get_broadcasts() returns the expected data
+     * when the slim parameter is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetBroadcastsSlim()
+    {
+        $result = $this->api->get_broadcasts(
+            slim: true
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+        $this->assertPaginationExists($result);
+
+        // Confirm content, public_url, email_address, email_template and subscriber_filter are excluded from the data.
+        $broadcast = get_object_vars($result->broadcasts[0]);
+        $this->assertArrayNotHasKey('content', $broadcast);
+        $this->assertArrayNotHasKey('public_url', $broadcast);
+        $this->assertArrayNotHasKey('email_address', $broadcast);
+        $this->assertArrayNotHasKey('email_template', $broadcast);
+        $this->assertArrayNotHasKey('subscriber_filter', $broadcast);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds support for the `slim` parameter on the `get_broadcasts` and `get_subscriber_tags` method, which was added to the API on May 20th 2026:
https://developers.kit.com/changelog#-new-slim-query-parameter-on-heavy-list-endpoints

## Testing

- `testGetTagSubscriptionsSlim`: Test that get_tag_subscriptions() returns the expected data when the slim parameter is specified.
- `testGetBroadcastsSlim `: Test that get_broadcasts() returns the expected data when the slim parameter is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)