### PR TITLE
Add `type` and `states` to `filter_subscribers()`

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1538,6 +1538,10 @@ trait ConvertKit_API_Traits
         foreach ($all as $condition) {
             $option = [];
 
+            if (array_key_exists('type', $condition) && !empty($condition['type'])) {
+                $option['type'] = $condition['type'];
+            }
+
             if (array_key_exists('count_greater_than', $condition) && $condition['count_greater_than'] !== null) {
                 $option['count_greater_than'] = $condition['count_greater_than'];
             }
@@ -1552,6 +1556,10 @@ trait ConvertKit_API_Traits
 
             if (array_key_exists('before', $condition) && $condition['before'] instanceof \DateTime) {
                 $option['before'] = $condition['before']->format('Y-m-d');
+            }
+
+            if (array_key_exists('states', $condition) && !empty($condition['states'])) {
+                $option['states'] = (array) $condition['states'];
             }
 
             if (array_key_exists('any', $condition) && !empty($condition['any'])) {

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1514,6 +1514,7 @@ trait ConvertKit_API_Traits
      *                                                              - 'count_less_than' (int|null).
      *                                                              - 'after' (\DateTime|null).
      *                                                              - 'before' (\DateTime|null).
+     *                                                              - 'states' (array<string>).
      *                                                              - 'any' (array<int|string, mixed>|null).
      * @param boolean                          $include_total_count To include the total count of records in the response, use true.
      * @param string                           $after_cursor        Return results after the given pagination cursor.

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4491,17 +4491,11 @@ class ConvertKitAPITest extends TestCase
      */
     public function testFilterSubscribersWithNoParameters()
     {
-        $this->expectException(ClientException::class);
-        $result = $this->api->filter_subscribers(
-            [
-                [
-                    'foo' => 'bar',
-                ],
-                [
-                    'type' => 'not-a-real-type',
-                ]
-            ]
-        );
+        $result = $this->api->filter_subscribers();
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
     }
 
     /**
@@ -4514,11 +4508,17 @@ class ConvertKitAPITest extends TestCase
      */
     public function testFilterSubscribersWithInvalidParameters()
     {
-        $result = $this->api->filter_subscribers();
-
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+        $this->expectException(ClientException::class);
+        $result = $this->api->filter_subscribers(
+            [
+                [
+                    'foo' => 'bar',
+                ],
+                [
+                    'type' => 'not-a-real-type',
+                ]
+            ]
+        );
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4483,13 +4483,36 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that filter_subscribers() returns the expected data
-     * when multiple any conditions are specified.
+     * when no parameters are specified.
      *
      * @since   2.4.0
      *
      * @return void
      */
     public function testFilterSubscribersWithNoParameters()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->filter_subscribers(
+            [
+                [
+                    'foo' => 'bar',
+                ],
+                [
+                    'type' => 'not-a-real-type',
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Test that filter_subscribers() throws a ClientException
+     * when invalid parameters are specified.
+     *
+     * @since   2.4.0
+     *
+     * @return void
+     */
+    public function testFilterSubscribersWithInvalidParameters()
     {
         $result = $this->api->filter_subscribers();
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4438,6 +4438,9 @@ class ConvertKitAPITest extends TestCase
                     'count_less_than' => 100,
                     'after' => new \DateTime('2024-01-01'),
                     'before' => new \DateTime('2027-01-01'),
+                    'states' => [
+                        'active',
+                    ],
                 ]
             ]
         );
@@ -4465,6 +4468,9 @@ class ConvertKitAPITest extends TestCase
                     'count_less_than' => 100,
                     'after' => new \DateTime('2024-01-01'),
                     'before' => new \DateTime('2027-01-01'),
+                    'states' => [
+                        'active',
+                    ],
                 ],
                 [
                     'type' => 'clicks',

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4499,7 +4499,7 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that filter_subscribers() throws a ClientException
+     * Test that filter_subscribers() throws a ServerException
      * when invalid parameters are specified.
      *
      * @since   2.4.0
@@ -4508,7 +4508,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testFilterSubscribersWithInvalidParameters()
     {
-        $this->expectException(ClientException::class);
+        $this->expectException(ServerException::class);
         $result = $this->api->filter_subscribers(
             [
                 [


### PR DESCRIPTION
## Summary

Adds support for `type` and `states` parameters for the `filter_subscribers()` method.

## Testing

- `testFilterSubscribersWithInvalidParameters`: Test that a ClientException is thrown when invalid parameters are sent to the API.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)