### PR TITLE
Add `slim` query parameter

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -332,6 +332,7 @@ trait ConvertKit_API_Traits
      * @param \DateTime|null $created_before      Filter subscribers who have been created before this date.
      * @param \DateTime|null $added_after         Filter subscribers who have been added to the form after this date.
      * @param \DateTime|null $added_before        Filter subscribers who have been added to the form before this date.
+     * @param boolean        $slim                When true, omits expensive optional fields from the response.
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -348,13 +349,14 @@ trait ConvertKit_API_Traits
         \DateTime|null $created_before = null,
         \DateTime|null $added_after = null,
         \DateTime|null $added_before = null,
+        bool $slim = false,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
         // Build parameters.
-        $options = [];
+        $options = ['slim' => $slim];
 
         if (!empty($subscriber_state)) {
             $options['status'] = $subscriber_state;
@@ -1363,6 +1365,7 @@ trait ConvertKit_API_Traits
      * @param string         $sort_field          Sort Field (id|updated_at|cancelled_at).
      * @param string         $sort_order          Sort Order (asc|desc).
      * @param array<string>  $include             Additional fields to include: attribution, tags, location, canceled_at.
+     * @param boolean        $slim                When true, omits expensive optional fields from the response.
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -1384,13 +1387,14 @@ trait ConvertKit_API_Traits
         string $sort_field = 'id',
         string $sort_order = 'desc',
         array $include = [],
+        bool $slim = false,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
         // Build parameters.
-        $options = [];
+        $options = ['slim' => $slim];
 
         if (!empty($subscriber_state)) {
             $options['status'] = $subscriber_state;

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -691,6 +691,30 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_form_subscriptions() returns the expected data
+     * when the slim parameter is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithSlimParameter()
+    {
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            slim: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Confirm custom field values are excluded from the data.
+        $subscriber = get_object_vars($result->subscribers[0]);
+        $this->assertArrayNotHasKey('fields', $subscriber);
+    }
+
+    /**
+     * Test that get_form_subscriptions() returns the expected data
      * when the total count is included.
      *
      * @since   2.0.0
@@ -3827,6 +3851,29 @@ class ConvertKitAPITest extends TestCase
         // Assert subscribers and pagination exist.
         $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
+    }
+
+     /**
+     * Test that get_subscribers() returns the expected data
+     * when the slim parameter is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetSubscribersWithSlimParameter()
+    {
+        $result = $this->api->get_subscribers(
+            slim: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Confirm custom field values are excluded from the data.
+        $subscriber = get_object_vars($result->subscribers[0]);
+        $this->assertArrayNotHasKey('fields', $subscriber);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds support for the `slim` parameter on the `get_subscribers` and `get_form_subscriptions` methods, which was added to the API on May 21st 2026:
https://developers.kit.com/changelog#may-21-2026-%E2%80%94-subscribers

## Testing

- `testGetFormSubscriptionsWithSlimParameter`: Test that get_form_subscriptions() returns the expected data when the slim parameter is specified.
- `testGetSubscribersWithSlimParameter`: Test that get_subscribers() returns the expected data when the slim parameter is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)