### PR TITLE
Add `status` query parameter to Broadcasts + Broadcasts Stats

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1753,6 +1753,7 @@ trait ConvertKit_API_Traits
      * @param \DateTime|null $sent_after          Get broadcasts sent after the given date.
      * @param \DateTime|null $sent_before         Get broadcasts sent before the given date.
      * @param boolean        $slim                When true, omits expensive optional fields from the response.
+     * @param string|null    $status              Get broadcasts with the given status (draft, scheduled, sending, completed, aborted).
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -1766,6 +1767,7 @@ trait ConvertKit_API_Traits
         \DateTime|null $sent_after = null,
         \DateTime|null $sent_before = null,
         bool $slim = false,
+        string|null $status = null,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -1774,6 +1776,9 @@ trait ConvertKit_API_Traits
         // Build parameters.
         $options = ['slim' => $slim];
 
+        if (!is_null($status)) {
+            $options['status'] = $status;
+        }
         if (!is_null($sent_after)) {
             $options['sent_after'] = $sent_after->format('Y-m-d');
         }
@@ -1935,6 +1940,7 @@ trait ConvertKit_API_Traits
      *
      * @param \DateTime|null $sent_after          Get broadcasts sent after the given date.
      * @param \DateTime|null $sent_before         Get broadcasts sent before the given date.
+     * @param string|null    $status              Get broadcasts with the given status (draft, scheduled, sending, completed, aborted).
      * @param boolean        $include_total_count To include the total count of records in the response, use true.
      * @param string         $after_cursor        Return results after the given pagination cursor.
      * @param string         $before_cursor       Return results before the given pagination cursor.
@@ -1949,6 +1955,7 @@ trait ConvertKit_API_Traits
     public function get_broadcasts_stats(
         \DateTime|null $sent_after = null,
         \DateTime|null $sent_before = null,
+        string|null $status = null,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -1957,6 +1964,9 @@ trait ConvertKit_API_Traits
         // Build parameters.
         $options = [];
 
+        if (!is_null($status)) {
+            $options['status'] = $status;
+        }
         if (!is_null($sent_after)) {
             $options['sent_after'] = $sent_after->format('Y-m-d');
         }

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -5345,6 +5345,46 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_broadcasts() returns the expected data
+     * when the completed status is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetBroadcastsWithCompletedStatus()
+    {
+        $result = $this->api->get_broadcasts(
+            status: 'completed'
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+    }
+
+    /**
+     * Test that get_broadcasts() returns the expected data
+     * when the aborted status is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetBroadcastsWithAbortedStatus()
+    {
+        $result = $this->api->get_broadcasts(
+            status: 'aborted'
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+        $this->assertPaginationExists($result);
+
+        // Assert no broadcasts were returned.
+        $this->assertCount(0, $result->broadcasts);
+    }
+
+    /**
+     * Test that get_broadcasts() returns the expected data
      * when pagination parameters and per_page limits are specified.
      *
      * @since   2.0.0
@@ -5738,6 +5778,50 @@ class ConvertKitAPITest extends TestCase
 
         // Assert the expected number of broadcasts were returned.
         $this->assertCount(12, $result->broadcasts);
+    }
+
+    /**
+     * Test that get_broadcasts_stats() returns the expected data
+     * when the completed status is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetBroadcastsStatsWithCompletedStatus()
+    {
+        $result = $this->api->get_broadcasts_stats(
+            status: 'completed'
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+        $this->assertPaginationExists($result);
+
+        // Assert the expected number of broadcasts were returned.
+        $this->assertCount(12, $result->broadcasts);
+    }
+
+    /**
+     * Test that get_broadcasts_stats() returns the expected data
+     * when the aborted status is specified.
+     *
+     * @since   2.5
+     *
+     * @return void
+     */
+    public function testGetBroadcastsStatsWithAbortedStatus()
+    {
+        $result = $this->api->get_broadcasts_stats(
+            status: 'aborted'
+        );
+
+        // Assert broadcasts and pagination exist.
+        $this->assertDataExists($result, 'broadcasts');
+        $this->assertPaginationExists($result);
+
+        // Assert the expected number of broadcasts were returned.
+        $this->assertCount(0, $result->broadcasts);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds support for the `status` parameter on the `get_broadcasts` and `get_broadcasts_stats` methods, which was added to the API on May 26th 2026:
https://developers.kit.com/changelog#may-26-2026-%E2%80%94-broadcasts

## Testing

- `testGetBroadcastsWithCompletedStatus`: Test that get_broadcasts() returns the expected data when the completed status is specified.
- `testGetBroadcastsWithAbortedStatus`: Test that get_broadcasts() returns the expected data when the aborted status is specified.
- `testGetBroadcastsStatsWithCompletedStatus`: Test that get_broadcasts_stats() returns the expected data when the completed status is specified.
- `testGetBroadcastsStatsWithAbortedStatus`: Test that get_broadcasts_stats() returns the expected data when the aborted status is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)