### PR TITLE
Fix Tests

### DIFF
--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1755,7 +1755,7 @@ class ConvertKitAPITest extends TestCase
             preview_text: 'Test Preview Text',
             content: 'Test Content',
             email_template_id: (int) $_ENV['CONVERTKIT_API_EMAIL_TEMPLATE_ID'],
-            published: false,
+            published: true,
             send_days: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
             position: 0
         );
@@ -1770,7 +1770,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertEquals('Test Preview Text', $result['preview_text']);
         $this->assertEquals('Test Content', $result['content']);
         $this->assertEquals((int) $_ENV['CONVERTKIT_API_EMAIL_TEMPLATE_ID'], $result['email_template_id']);
-        $this->assertEquals(false, $result['published']);
+        $this->assertEquals(true, $result['published']);
         $this->assertEquals(['monday', 'tuesday', 'wednesday', 'thursday', 'friday'], $result['send_days']);
         $this->assertEquals(2, $result['position']);
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4329,8 +4329,8 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that create_subscriber() throws a ClientException when an invalid
-     * custom field is included.
+     * Test that create_subscriber() returns the expected warnings
+     * when an invalid custom field is included.
      *
      * @since   2.0.0
      *
@@ -4338,7 +4338,6 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateSubscriberWithInvalidCustomFields()
     {
-        $this->expectException(ClientException::class);
         $emailAddress = $this->generateEmailAddress();
         $result = $this->api->create_subscriber(
             email_address: $emailAddress,
@@ -4346,6 +4345,7 @@ class ConvertKitAPITest extends TestCase
                 'not_a_custom_field' => 'value'
             ]
         );
+        $this->assertArrayHasKey('warnings', get_object_vars($result));
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes:
- `testCreateGetUpdateAndDeleteSequenceEmail`, by setting the sequence email as published on creation, as the API won't reflect the specified `email_template_id` otherwise: https://wpzinc.slack.com/archives/C02KFR6N1GF/p1781001620443109
- `testCreateSubscriberWithInvalidCustomFields`, as the API now returns a `warnings` array instead of a 4xx error: https://developers.kit.com/api-reference/subscribers/create-a-subscriber

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)