### PR TITLE
Add `counting_mode` to `filter_subscribers` method

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1538,7 +1538,7 @@ trait ConvertKit_API_Traits
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        $options = ['counting_mode' => $counting_mode];
+        $options = [];
 
         foreach ($all as $condition) {
             $option = [];
@@ -1577,7 +1577,10 @@ trait ConvertKit_API_Traits
         return $this->post(
             'subscribers/filter',
             $this->build_total_count_and_pagination_params(
-                ['all' => $options],
+                [
+                    'all'           => $options,
+                    'counting_mode' => $counting_mode,
+                ],
                 $include_total_count,
                 $after_cursor,
                 $before_cursor,

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1516,6 +1516,9 @@ trait ConvertKit_API_Traits
      *                                                              - 'before' (\DateTime|null).
      *                                                              - 'states' (array<string>).
      *                                                              - 'any' (array<int|string, mixed>|null).
+     * @param string                           $counting_mode       Controls how engagement-filter count thresholds are tallied.
+     *                                                              - 'raw' (default) counts every event — five opens of the same email = five.
+     *                                                              - 'unique_email' counts distinct emails on which the action occurred.
      * @param boolean                          $include_total_count To include the total count of records in the response, use true.
      * @param string                           $after_cursor        Return results after the given pagination cursor.
      * @param string                           $before_cursor       Return results before the given pagination cursor.
@@ -1529,12 +1532,13 @@ trait ConvertKit_API_Traits
      */
     public function filter_subscribers(
         array $all = [],
+        string $counting_mode = 'raw',
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        $options = [];
+        $options = ['counting_mode' => $counting_mode];
 
         foreach ($all as $condition) {
             $option = [];

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4489,6 +4489,37 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that filter_subscribers() returns the expected data
+     * when a counting mode is specified.
+     *
+     * @since   2.4.0
+     *
+     * @return void
+     */
+    public function testFilterSubscribersWithCountingMode()
+    {
+        $result = $this->api->filter_subscribers(
+            all: [
+                [
+                    'type' => 'opens',
+                    'count_greater_than' => 10,
+                    'count_less_than' => 100,
+                    'after' => new \DateTime('2024-01-01'),
+                    'before' => new \DateTime('2027-01-01'),
+                    'states' => [
+                        'active',
+                    ],
+                ]
+            ],
+            counting_mode: 'unique_email'
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+    }
+
+    /**
+     * Test that filter_subscribers() returns the expected data
      * when no parameters are specified.
      *
      * @since   2.4.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4491,7 +4491,7 @@ class ConvertKitAPITest extends TestCase
      * Test that filter_subscribers() returns the expected data
      * when a counting mode is specified.
      *
-     * @since   2.4.0
+     * @since   2.5.0
      *
      * @return void
      */


### PR DESCRIPTION
## Summary

Adds support for the `counting_mode` parameter for the `filter_subscribers()` method:
https://developers.kit.com/api-reference/subscribers/filter-subscribers-based-on-engagement#body-counting-mode

## Testing

- `testFilterSubscribersWithCountingMode`: Test that filter_subscribers() returns the expected data when a counting mode is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)