### PR TITLE
Tests: Update GitHub Actions for Node 20 deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,8 @@ jobs:
       # The formatting of the contents to include a blank newline is deliberate.
       - name: Define GitHub Secrets in .env.dist.testing
         run: |
-            cat > .env.dist.testing << 'ENVEOF'
+            cat >> .env.dist.testing <<EOF
+            
             CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.KIT_OAUTH_ACCESS_TOKEN }}
             CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.KIT_OAUTH_REFRESH_TOKEN }}
             CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.KIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
@@ -68,7 +69,7 @@ jobs:
             CONVERTKIT_OAUTH_CLIENT_ID=${{ secrets.CONVERTKIT_OAUTH_CLIENT_ID }}
             CONVERTKIT_OAUTH_CLIENT_SECRET=${{ secrets.CONVERTKIT_OAUTH_CLIENT_SECRET }}
             CONVERTKIT_OAUTH_REDIRECT_URI=${{ secrets.CONVERTKIT_OAUTH_REDIRECT_URI }}
-            ENVEOF
+            EOF
 
       # Rename .env.dist.testing to .env, so PHPUnit reads it for tests.
       - name: Rename .env.dist.testing to .env 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,11 +58,8 @@ jobs:
       # Make sure your committed .env.dist.testing file ends with a newline.
       # The formatting of the contents to include a blank newline is deliberate.
       - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.3
-        with:
-          path: .env.dist.testing
-          contents: |
-
+        run: |
+            cat > .env.dist.testing << 'ENVEOF'
             CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.KIT_OAUTH_ACCESS_TOKEN }}
             CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.KIT_OAUTH_REFRESH_TOKEN }}
             CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.KIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
@@ -71,7 +68,7 @@ jobs:
             CONVERTKIT_OAUTH_CLIENT_ID=${{ secrets.CONVERTKIT_OAUTH_CLIENT_ID }}
             CONVERTKIT_OAUTH_CLIENT_SECRET=${{ secrets.CONVERTKIT_OAUTH_CLIENT_SECRET }}
             CONVERTKIT_OAUTH_REDIRECT_URI=${{ secrets.CONVERTKIT_OAUTH_REDIRECT_URI }}
-          write-mode: append
+            ENVEOF
 
       # Rename .env.dist.testing to .env, so PHPUnit reads it for tests.
       - name: Rename .env.dist.testing to .env 


### PR DESCRIPTION
## Summary

Replaces `DamianReeves/write-file-action` with a shell command, as there's no new version using Node version above 20. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)