### PR TITLE
Filter Subscribers: Add `include` parameter support

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1576,6 +1576,7 @@ trait ConvertKit_API_Traits
      * @param string                           $counting_mode       Controls how engagement-filter count thresholds are tallied.
      *                                                              - 'raw' (default) counts every event — five opens of the same email = five.
      *                                                              - 'unique_email' counts distinct emails on which the action occurred.
+     * @param array<int, array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
      * @param boolean                          $include_total_count To include the total count of records in the response, use true.
      * @param string                           $after_cursor        Return results after the given pagination cursor.
      * @param string                           $before_cursor       Return results before the given pagination cursor.
@@ -1590,6 +1591,7 @@ trait ConvertKit_API_Traits
     public function filter_subscribers(
         array $all = [],
         string $counting_mode = 'raw',
+        array $include = [],
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -1637,6 +1639,7 @@ trait ConvertKit_API_Traits
                 [
                     'all'           => $options,
                     'counting_mode' => $counting_mode,
+                    'include'       => $include,
                 ],
                 $include_total_count,
                 $after_cursor,

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1565,22 +1565,22 @@ trait ConvertKit_API_Traits
     /**
      * Filter subscribers based on engagement.
      *
-     * @param array<int, array<string, mixed>> $all                 Array of filter conditions where ALL must be met (AND logic). Each condition can have.
-     *                                                              - 'type' (string).
-     *                                                              - 'count_greater_than' (int|null).
-     *                                                              - 'count_less_than' (int|null).
-     *                                                              - 'after' (\DateTime|null).
-     *                                                              - 'before' (\DateTime|null).
-     *                                                              - 'states' (array<string>).
-     *                                                              - 'any' (array<int|string, mixed>|null).
-     * @param string                           $counting_mode       Controls how engagement-filter count thresholds are tallied.
-     *                                                              - 'raw' (default) counts every event — five opens of the same email = five.
-     *                                                              - 'unique_email' counts distinct emails on which the action occurred.
-     * @param array<int, array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
-     * @param boolean                          $include_total_count To include the total count of records in the response, use true.
-     * @param string                           $after_cursor        Return results after the given pagination cursor.
-     * @param string                           $before_cursor       Return results before the given pagination cursor.
-     * @param integer                          $per_page            Number of results to return.
+     * @param list<array<string, mixed>> $all                 Array of filter conditions where ALL must be met (AND logic). Each condition can have.
+     *                                                        - 'type' (string).
+     *                                                        - 'count_greater_than' (int|null).
+     *                                                        - 'count_less_than' (int|null).
+     *                                                        - 'after' (\DateTime|null).
+     *                                                        - 'before' (\DateTime|null).
+     *                                                        - 'states' (array<string>).
+     *                                                        - 'any' (array<int|string, mixed>|null).
+     * @param string                     $counting_mode       Controls how engagement-filter count thresholds are tallied.
+     *                                                        - 'raw' (default) counts every event — five opens of the same email = five.
+     *                                                        - 'unique_email' counts distinct emails on which the action occurred.
+     * @param list<array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
+     * @param boolean                    $include_total_count To include the total count of records in the response, use true.
+     * @param string                     $after_cursor        Return results after the given pagination cursor.
+     * @param string                     $before_cursor       Return results before the given pagination cursor.
+     * @param integer                    $per_page            Number of results to return.
      *
      * @since 2.4.0
      *

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4603,6 +4603,44 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that filter_subscribers() returns the expected data
+     * when the `include` parameter is specified.
+     *
+     * @since   2.6.0
+     *
+     * @return void
+     */
+    public function testFilterSubscribersWithInclude()
+    {
+        $result = $this->api->filter_subscribers(
+            all: [
+                [
+                    'type' => 'opens',
+                    'count_greater_than' => 0,
+                    'count_less_than' => 100,
+                    'after' => new \DateTime('2024-01-01'),
+                    'before' => new \DateTime('2029-01-01'),
+                    'states' => [
+                        'active',
+                    ],
+                ]
+            ],
+            include: [
+                [
+                    'type' => 'tags',
+                ],
+            ]
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Assert tags are included.
+        $this->assertArrayHasKey('tags', get_object_vars($result->subscribers[0]));
+    }
+
+    /**
+     * Test that filter_subscribers() returns the expected data
      * when no parameters are specified.
      *
      * @since   2.4.0


### PR DESCRIPTION
## Summary

Adds support for the `include` parameter for filtering subscribers:
https://developers.kit.com/changelog#june-30-2026-%E2%80%94-subscribers

## Testing

Added tests to confirm specifying an `include` parameter returns the expected data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)