### PR TITLE
Fix Sequence Tests

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -158,11 +158,12 @@ trait ConvertKit_API_Traits
     /**
      * List forms.
      *
-     * @param string  $status              Form status (active|archived|trashed|all).
-     * @param boolean $include_total_count To include the total count of records in the response, use true.
-     * @param string  $after_cursor        Return results after the given pagination cursor.
-     * @param string  $before_cursor       Return results before the given pagination cursor.
-     * @param integer $per_page            Number of results to return.
+     * @param string        $status              Form status (active|archived|trashed|all).
+     * @param array<string> $include             Additional fields to include: subscriber_count.
+     * @param boolean       $include_total_count To include the total count of records in the response, use true.
+     * @param string        $after_cursor        Return results after the given pagination cursor.
+     * @param string        $before_cursor       Return results before the given pagination cursor.
+     * @param integer       $per_page            Number of results to return.
      *
      * @see https://developers.kit.com/api-reference/forms/list-forms
      *
@@ -170,18 +171,26 @@ trait ConvertKit_API_Traits
      */
     public function get_forms(
         string $status = 'active',
+        array $include = [],
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
+        // Build parameters.
+        $options = [
+            'type'   => 'embed',
+            'status' => $status,
+        ];
+
+        if (!empty($include)) {
+            $options['include'] = implode(',', $include);
+        }
+
         return $this->get(
             'forms',
             $this->build_total_count_and_pagination_params(
-                [
-                    'type'   => 'embed',
-                    'status' => $status,
-                ],
+                $options,
                 $include_total_count,
                 $after_cursor,
                 $before_cursor,
@@ -1004,10 +1013,11 @@ trait ConvertKit_API_Traits
     /**
      * List tags.
      *
-     * @param boolean $include_total_count To include the total count of records in the response, use true.
-     * @param string  $after_cursor        Return results after the given pagination cursor.
-     * @param string  $before_cursor       Return results before the given pagination cursor.
-     * @param integer $per_page            Number of results to return.
+     * @param array<string> $include             Additional fields to include: subscriber_count.
+     * @param boolean       $include_total_count To include the total count of records in the response, use true.
+     * @param string        $after_cursor        Return results after the given pagination cursor.
+     * @param string        $before_cursor       Return results before the given pagination cursor.
+     * @param integer       $per_page            Number of results to return.
      *
      * @see https://developers.kit.com/api-reference/tags/list-tags
      *
@@ -1016,15 +1026,23 @@ trait ConvertKit_API_Traits
      * @return mixed|array<int,\stdClass>
      */
     public function get_tags(
+        array $include = [],
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
+        // Build parameters.
+        $options = [];
+
+        if (!empty($include)) {
+            $options['include'] = implode(',', $include);
+        }
+
         return $this->get(
             'tags',
             $this->build_total_count_and_pagination_params(
-                [],
+                $options,
                 $include_total_count,
                 $after_cursor,
                 $before_cursor,

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1104,6 +1104,41 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Bulk delete tags.
+     *
+     * @param array<int> $tag_ids      Tag IDs.
+     * @param string     $callback_url URL to notify for large batch size when async processing complete.
+     *
+     * @since 2.6.0
+     *
+     * @see https://developers.kit.com/api-reference/tags/bulk-delete-tags
+     *
+     * @return false|mixed
+     */
+    public function delete_tags(array $tag_ids, string $callback_url = '')
+    {
+        // Build parameters.
+        $options = [
+            'tags' => [],
+        ];
+        foreach ($tag_ids as $i => $tag_id) {
+            $options['tags'][] = [
+                'id' => (int) $tag_id,
+            ];
+        }
+
+        if (!empty($callback_url)) {
+            $options['callback_url'] = $callback_url;
+        }
+
+        // Send request.
+        return $this->delete(
+            'bulk/tags',
+            $options
+        );
+    }
+
+    /**
      * Updates the name of a tag.
      *
      * @param integer $tag_id Tag ID.
@@ -2688,8 +2723,8 @@ trait ConvertKit_API_Traits
     /**
      * Performs a DELETE request to the API.
      *
-     * @param string                                                     $endpoint API Endpoint.
-     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
+     * @param string                                                                                                                  $endpoint API Endpoint.
+     * @param array<string, bool|integer|float|string|null|array<int|string, array<string, int|string>|boolean|integer|float|string>> $args     Request arguments.
      *
      * @return false|mixed
      */

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1576,6 +1576,7 @@ trait ConvertKit_API_Traits
      * @param string                           $counting_mode       Controls how engagement-filter count thresholds are tallied.
      *                                                              - 'raw' (default) counts every event — five opens of the same email = five.
      *                                                              - 'unique_email' counts distinct emails on which the action occurred.
+     * @param array<int, array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
      * @param boolean                          $include_total_count To include the total count of records in the response, use true.
      * @param string                           $after_cursor        Return results after the given pagination cursor.
      * @param string                           $before_cursor       Return results before the given pagination cursor.
@@ -1590,6 +1591,7 @@ trait ConvertKit_API_Traits
     public function filter_subscribers(
         array $all = [],
         string $counting_mode = 'raw',
+        array $include = [],
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -1637,6 +1639,7 @@ trait ConvertKit_API_Traits
                 [
                     'all'           => $options,
                     'counting_mode' => $counting_mode,
+                    'include'       => $include,
                 ],
                 $include_total_count,
                 $after_cursor,

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1565,22 +1565,22 @@ trait ConvertKit_API_Traits
     /**
      * Filter subscribers based on engagement.
      *
-     * @param array<int, array<string, mixed>> $all                 Array of filter conditions where ALL must be met (AND logic). Each condition can have.
-     *                                                              - 'type' (string).
-     *                                                              - 'count_greater_than' (int|null).
-     *                                                              - 'count_less_than' (int|null).
-     *                                                              - 'after' (\DateTime|null).
-     *                                                              - 'before' (\DateTime|null).
-     *                                                              - 'states' (array<string>).
-     *                                                              - 'any' (array<int|string, mixed>|null).
-     * @param string                           $counting_mode       Controls how engagement-filter count thresholds are tallied.
-     *                                                              - 'raw' (default) counts every event — five opens of the same email = five.
-     *                                                              - 'unique_email' counts distinct emails on which the action occurred.
-     * @param array<int, array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
-     * @param boolean                          $include_total_count To include the total count of records in the response, use true.
-     * @param string                           $after_cursor        Return results after the given pagination cursor.
-     * @param string                           $before_cursor       Return results before the given pagination cursor.
-     * @param integer                          $per_page            Number of results to return.
+     * @param list<array<string, mixed>> $all                 Array of filter conditions where ALL must be met (AND logic). Each condition can have.
+     *                                                        - 'type' (string).
+     *                                                        - 'count_greater_than' (int|null).
+     *                                                        - 'count_less_than' (int|null).
+     *                                                        - 'after' (\DateTime|null).
+     *                                                        - 'before' (\DateTime|null).
+     *                                                        - 'states' (array<string>).
+     *                                                        - 'any' (array<int|string, mixed>|null).
+     * @param string                     $counting_mode       Controls how engagement-filter count thresholds are tallied.
+     *                                                        - 'raw' (default) counts every event — five opens of the same email = five.
+     *                                                        - 'unique_email' counts distinct emails on which the action occurred.
+     * @param list<array<string, mixed>> $include             Array of additional fields to embed on each subscriber row.
+     * @param boolean                    $include_total_count To include the total count of records in the response, use true.
+     * @param string                     $after_cursor        Return results after the given pagination cursor.
+     * @param string                     $before_cursor       Return results before the given pagination cursor.
+     * @param integer                    $per_page            Number of results to return.
      *
      * @since 2.4.0
      *

--- a/tests/ConvertKitAPIKeyTest.php
+++ b/tests/ConvertKitAPIKeyTest.php
@@ -237,12 +237,18 @@ class ConvertKitAPIKeyTest extends ConvertKitAPITest
      *
      * @return void
      */
-    public function testCreateTags()
+    public function testCreateAndDeleteTags()
     {
         $this->expectException(ClientException::class);
         $result = $this->api->create_tags([
             'Tag Test ' . mt_rand(),
             'Tag Test ' . mt_rand(),
+        ]);
+
+        $this->expectException(ClientException::class);
+        $result = $this->api->delete_tags([
+            12345,
+            23456,
         ]);
     }
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -2410,41 +2410,33 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that create_tags() returns the expected data.
+     * Test that create_tags() and delete_tags() returns the expected data.
      *
      * @since   1.1.0
      *
      * @return void
      */
-    public function testCreateTags()
+    public function testCreateAndDeleteTags()
     {
         $tagNames = [
             'Tag Test ' . mt_rand(),
             'Tag Test ' . mt_rand(),
         ];
 
-        // Add mock handler for this API request, as the API doesn't provide
-        // a method to delete tags to cleanup the test.
-        $this->api = $this->mockResponse(
-            api: $this->api,
-            responseBody: [
-                'tags' => [
-                    [
-                        'id' => 12345,
-                        'name' => $tagNames[0],
-                        'created_at' => date('Y-m-d') . 'T' . date('H:i:s') . 'Z',
-                    ],
-                    [
-                        'id' => 23456,
-                        'name' => $tagNames[1],
-                        'created_at' => date('Y-m-d') . 'T' . date('H:i:s') . 'Z',
-                    ],
-                ],
-                'failures' => [],
-            ]
-        );
-
+        // Create tags.
         $result = $this->api->create_tags($tagNames);
+
+        // Assert no failures.
+        $this->assertCount(0, $result->failures);
+
+        // Build tag IDs array.
+        $ids = [];
+        foreach ($result->tags as $tag) {
+            $ids[] = $tag->id;
+        }
+
+        // Delete tags.
+        $result = $this->api->delete_tags($ids);
 
         // Assert no failures.
         $this->assertCount(0, $result->failures);

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1816,7 +1816,7 @@ class ConvertKitAPITest extends TestCase
             email_template_id: (int) $_ENV['CONVERTKIT_API_EMAIL_TEMPLATE_ID'],
             published: true,
             send_days: ['saturday', 'sunday'],
-            position: 1,
+            position: 2,
         );
 
         // Confirm the changes saved.
@@ -1830,7 +1830,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertEquals((int) $_ENV['CONVERTKIT_API_EMAIL_TEMPLATE_ID'], $result['email_template_id']);
         $this->assertEquals(true, $result['published']);
         $this->assertEquals(['saturday', 'sunday'], $result['send_days']);
-        $this->assertEquals(1, $result['position']);
+        $this->assertEquals(2, $result['position']);
 
         // Delete Sequence Email.
         $this->api->delete_sequence_email((int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'], $sequenceEmailID);

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -446,6 +446,28 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_forms() returns the subscriber count
+     * when included in the `include` argument.
+     *
+     * @since   2.6.0
+     *
+     * @return void
+     */
+    public function testGetFormsWithSubscriberCount()
+    {
+        $result = $this->api->get_forms(
+            include: ['subscriber_count']
+        );
+
+        // Assert forms and pagination exist.
+        $this->assertDataExists($result, 'forms');
+        $this->assertPaginationExists($result);
+
+        // Assert subscriber count is included.
+        $this->assertArrayHasKey('subscriber_count', get_object_vars($result->forms[0]));
+    }
+
+    /**
      * Test that get_forms() returns the expected data
      * when the total count is included.
      *
@@ -2218,6 +2240,28 @@ class ConvertKitAPITest extends TestCase
         $this->assertArrayHasKey('id', $tag);
         $this->assertArrayHasKey('name', $tag);
         $this->assertArrayHasKey('created_at', $tag);
+    }
+
+    /**
+     * Test that get_tags() returns the subscriber count
+     * when included in the `include` argument.
+     *
+     * @since   2.6.0
+     *
+     * @return void
+     */
+    public function testGetTagsWithSubscriberCount()
+    {
+        $result = $this->api->get_tags(
+            include: ['subscriber_count']
+        );
+
+        // Assert forms and pagination exist.
+        $this->assertDataExists($result, 'tags');
+        $this->assertPaginationExists($result);
+
+        // Assert subscriber count is included.
+        $this->assertArrayHasKey('subscriber_count', get_object_vars($result->tags[0]));
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4603,6 +4603,44 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that filter_subscribers() returns the expected data
+     * when the `include` parameter is specified.
+     *
+     * @since   2.6.0
+     *
+     * @return void
+     */
+    public function testFilterSubscribersWithInclude()
+    {
+        $result = $this->api->filter_subscribers(
+            all: [
+                [
+                    'type' => 'opens',
+                    'count_greater_than' => 0,
+                    'count_less_than' => 100,
+                    'after' => new \DateTime('2024-01-01'),
+                    'before' => new \DateTime('2029-01-01'),
+                    'states' => [
+                        'active',
+                    ],
+                ]
+            ],
+            include: [
+                [
+                    'type' => 'tags',
+                ],
+            ]
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Assert tags are included.
+        $this->assertArrayHasKey('tags', get_object_vars($result->subscribers[0]));
+    }
+
+    /**
+     * Test that filter_subscribers() returns the expected data
      * when no parameters are specified.
      *
      * @since   2.4.0


### PR DESCRIPTION
## Summary

Fixes the create/update/delete sequence email test since the API changes rightly no longer permit setting a position of an existing email in a sequence to one that already exists.

```
1) ConvertKitAPIKeyTest::testCreateGetUpdateAndDeleteSequenceEmail
GuzzleHttp\Exception\ClientException: Client error: `PUT [https://api.kit.com/v4/sequences/1030824/emails/10087666`](https://api.kit.com/v4/sequences/1030824/emails/10087666%60) resulted in a `422 Unprocessable Content` response:
{"errors":["position 1 is already taken in this sequence"]}
```

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)