### PR TITLE
Filter Subscribers: Add support for new params

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1607,11 +1607,19 @@ trait ConvertKit_API_Traits
             }
 
             if (array_key_exists('count_greater_than', $condition) && $condition['count_greater_than'] !== null) {
-                $option['count_greater_than'] = $condition['count_greater_than'];
+                $option['count_greater_than'] = (int) $condition['count_greater_than'];
+            }
+
+            if (array_key_exists('count_greater_than_or_equal', $condition) && $condition['count_greater_than_or_equal'] !== null) {
+                $option['count_greater_than'] = (int) $condition['count_greater_than_or_equal'];
             }
 
             if (array_key_exists('count_less_than', $condition) && $condition['count_less_than'] !== null) {
-                $option['count_less_than'] = $condition['count_less_than'];
+                $option['count_less_than'] = (int) $condition['count_less_than'];
+            }
+
+            if (array_key_exists('count_less_than_or_equal', $condition) && $condition['count_less_than_or_equal'] !== null) {
+                $option['count_less_than_or_equal'] = (int) $condition['count_less_than_or_equal'];
             }
 
             if (array_key_exists('after', $condition) && $condition['after'] instanceof \DateTime) {
@@ -1624,6 +1632,30 @@ trait ConvertKit_API_Traits
 
             if (array_key_exists('states', $condition) && !empty($condition['states'])) {
                 $option['states'] = (array) $condition['states'];
+            }
+
+            if (array_key_exists('subscriber_custom_field_id', $condition) && $condition['subscriber_custom_field_id'] !== null) {
+                $option['subscriber_custom_field_id'] = (int) $condition['subscriber_custom_field_id'];
+            }
+
+            if (array_key_exists('value', $condition) && $condition['value'] !== null) {
+                $option['value'] = $condition['value'];
+            }
+
+            if (array_key_exists('comparison', $condition) && $condition['comparison'] !== null) {
+                $option['comparison'] = $condition['comparison'];
+            }
+
+            if (array_key_exists('latitude', $condition) && $condition['latitude'] !== null) {
+                $option['latitude'] = (float) $condition['latitude'];
+            }
+
+            if (array_key_exists('longitude', $condition) && $condition['longitude'] !== null) {
+                $option['longitude'] = (float) $condition['longitude'];
+            }
+
+            if (array_key_exists('radius', $condition) && $condition['radius'] !== null) {
+                $option['radius'] = $condition['radius'];
             }
 
             if (array_key_exists('any', $condition) && !empty($condition['any'])) {

--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -1606,19 +1606,19 @@ trait ConvertKit_API_Traits
                 $option['type'] = $condition['type'];
             }
 
-            if (array_key_exists('count_greater_than', $condition) && $condition['count_greater_than'] !== null) {
+            if (array_key_exists('count_greater_than', $condition) && is_numeric($condition['count_greater_than'])) {
                 $option['count_greater_than'] = (int) $condition['count_greater_than'];
             }
 
-            if (array_key_exists('count_greater_than_or_equal', $condition) && $condition['count_greater_than_or_equal'] !== null) {
-                $option['count_greater_than'] = (int) $condition['count_greater_than_or_equal'];
+            if (array_key_exists('count_greater_than_or_equal', $condition) && is_numeric($condition['count_greater_than_or_equal'])) {
+                $option['count_greater_than_or_equal'] = (int) $condition['count_greater_than_or_equal'];
             }
 
-            if (array_key_exists('count_less_than', $condition) && $condition['count_less_than'] !== null) {
+            if (array_key_exists('count_less_than', $condition) && is_numeric($condition['count_less_than'])) {
                 $option['count_less_than'] = (int) $condition['count_less_than'];
             }
 
-            if (array_key_exists('count_less_than_or_equal', $condition) && $condition['count_less_than_or_equal'] !== null) {
+            if (array_key_exists('count_less_than_or_equal', $condition) && is_numeric($condition['count_less_than_or_equal'])) {
                 $option['count_less_than_or_equal'] = (int) $condition['count_less_than_or_equal'];
             }
 
@@ -1634,7 +1634,7 @@ trait ConvertKit_API_Traits
                 $option['states'] = (array) $condition['states'];
             }
 
-            if (array_key_exists('subscriber_custom_field_id', $condition) && $condition['subscriber_custom_field_id'] !== null) {
+            if (array_key_exists('subscriber_custom_field_id', $condition) && is_numeric($condition['subscriber_custom_field_id'])) {
                 $option['subscriber_custom_field_id'] = (int) $condition['subscriber_custom_field_id'];
             }
 
@@ -1646,11 +1646,11 @@ trait ConvertKit_API_Traits
                 $option['comparison'] = $condition['comparison'];
             }
 
-            if (array_key_exists('latitude', $condition) && $condition['latitude'] !== null) {
+            if (array_key_exists('latitude', $condition) && is_numeric($condition['latitude'])) {
                 $option['latitude'] = (float) $condition['latitude'];
             }
 
-            if (array_key_exists('longitude', $condition) && $condition['longitude'] !== null) {
+            if (array_key_exists('longitude', $condition) && is_numeric($condition['longitude'])) {
                 $option['longitude'] = (float) $condition['longitude'];
             }
 


### PR DESCRIPTION
## Summary

Adds support for new parameters on `filter_subscribers`:
https://developers.kit.com/changelog#june-30-2026-%E2%80%94-subscribers

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)