### PR TITLE
Exclude anchor links from URL conversion

### DIFF
--- a/src/ConvertKit_API_Traits.php
+++ b/src/ConvertKit_API_Traits.php
@@ -2682,6 +2682,11 @@ trait ConvertKit_API_Traits
                 continue;
             }
 
+            // Skip if the attribute's value is an anchor.
+            if (strpos($element->getAttribute($attribute), '#') !== false) {
+                continue;
+            }
+
             // Remove element if it's rocket-loader.min.js. Including it prevents landing page redirects from working.
             if (strpos($element->getAttribute($attribute), 'rocket-loader.min.js') !== false) {
                 if ($element->parentNode instanceof \DOMNode) {

--- a/tests/ConvertKitMethodsTest.php
+++ b/tests/ConvertKitMethodsTest.php
@@ -47,6 +47,7 @@ class ConvertKitMethodsTest extends TestCase
             </head>
             <body>
                 <a href="/test">Test</a>
+                <a href="#anchor">Anchor</a>
                 <img src="/test.jpg" />
                 <script type="text/javascript" src="/test.js"></script>
                 <form action="/test">Test</form>
@@ -110,6 +111,12 @@ class ConvertKitMethodsTest extends TestCase
         );
         $this->assertStringContainsString(
             '<form action="' . $url_scheme_host_only . '/test">Test</form>',
+            $output
+        );
+
+        // Assert string contains expected HTML elements that should not be modified.
+        $this->assertStringContainsString(
+            '<a href="#anchor">Anchor</a>',
             $output
         );
     }


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BUIL-6355/builders-p4-landing-page-anchor-link-buttons-dont-navigate-correctly) by ensuring `convert_relative_to_absolute_urls` does not convert anchor links.

## Testing
- `testConvertRelativeToAbsoluteUrls`: Updated to confirm an anchor is not converted to an absolute URL.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)